### PR TITLE
Add wrapping class around individual modifiers

### DIFF
--- a/kss_styleguide/custom-template/index.hbs
+++ b/kss_styleguide/custom-template/index.hbs
@@ -129,11 +129,13 @@
                 <div class="kss-modifiers__example">{{{markup}}}</div>
 
                 {{#each modifiers}}
-                  <h2 class="kss-modifiers__name">{{name}}</h2>
+                  <div class="kss-modifiers__modifier">
+                    <h2 class="kss-modifiers__name">{{name}}</h2>
 
-                  <p class="kss-modifiers__description">{{{description}}}</p>
+                    <p class="kss-modifiers__description">{{{description}}}</p>
 
-                  <div class="kss-modifiers__example">{{{markup}}}</div>
+                    <div class="kss-modifiers__example">{{{markup}}}</div>
+                  </div>
                 {{/each}}
               </article>
 


### PR DESCRIPTION
Adding a wrapping class around the individual modifiers allows for better styling, for example when showing available icons (http://imgur.com/a/tT1DH) they can be formatted as a grid by floating the wrapping container.